### PR TITLE
Route parameters fix

### DIFF
--- a/framework/Route.php
+++ b/framework/Route.php
@@ -65,14 +65,14 @@ class Route {
         $uri = preg_replace(
             $this->regex,
             "(.+)",
-            $attrs['uri']
+            $attrs['route']
         );
         $uri = ltrim($uri, '/');
 
         $vars = [];
         preg_match_all(
             $this->regex,
-            $attrs['uri'],
+            $attrs['route'],
             $vars
         );
 


### PR DESCRIPTION
Route parameters didn't get passed to its controller because of the use of wrong $attr array label.